### PR TITLE
BUG: Re-implement re and ads_port specification

### DIFF
--- a/pytmc/xml_collector.py
+++ b/pytmc/xml_collector.py
@@ -6,6 +6,7 @@ interpretations. Db Files can be produced from the interpretation
 """
 import logging
 import functools
+import re
 import xml.etree.ElementTree as ET
 
 from collections import defaultdict

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -637,7 +637,7 @@ def test_BaseRecordPackage_guess_PINI():
 
 
 def test_BaseRecordPackage_guess_TSE():
-    brp = BaseRecordPackage(ads_port=851)
+    brp = BaseRecordPackage(851)
     assert brp.guess_TSE() is True
     [tse] = brp.cfg.get_config_fields('TSE')
     assert tse['tag']['f_set'] == '-2'

--- a/tests/test_xml_collector.py
+++ b/tests/test_xml_collector.py
@@ -637,7 +637,7 @@ def test_BaseRecordPackage_guess_PINI():
 
 
 def test_BaseRecordPackage_guess_TSE():
-    brp = BaseRecordPackage()
+    brp = BaseRecordPackage(ads_port=851)
     assert brp.guess_TSE() is True
     [tse] = brp.cfg.get_config_fields('TSE')
     assert tse['tag']['f_set'] == '-2'


### PR DESCRIPTION
During a previous commit, the `import re` statement must have been incidentally removed and `ads_port` left undefined. This PR fixes those issues. 